### PR TITLE
Rpc node benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,38 @@ It also publishes the following alerts:
 
 At the moment, this script sends alerts to stdout.
 If you would like notifications via another medium (e.g., Slack), please let us know!
+
+## RPC Benchmark
+
+Pyth publishers often need high-performance Solana RPC nodes in order to handle the transaction load.
+This package comes with a program to benchmark RPC node performance:
+
+```
+npm run benchmark
+```
+
+The benchmark program will use the RPC node configured in the `.env` file.
+This program will generate synthetic load on the RPC node at a fixed number of queries/second, then measure the latency of additional specific API calls.
+Example output from the program is as follows:
+
+```
+Warming up RPC node...
+Testing at 0 queries per second
+  getSlot: 47.7 ± 6.5 ms p90: 58.0 p95: 60.6 p99: 70.4
+  getRecentBlockhash: 69.1 ± 54.8 ms p90: 164.5 p95: 181.5 p99: 338.9
+  getProgramAccounts for Pyth: 108.5 ± 54.4 ms p90: 145.9 p95: 213.6 p99: 391.0
+  getAccount for Pyth BTC/USD price feed: 52.2 ± 25.3 ms p90: 72.1 p95: 110.8 p99: 238.5
+...
+Testing at 100 queries per second
+  getSlot: 51.0 ± 23.0 ms p90: 73.7 p95: 116.8 p99: 182.8
+  getRecentBlockhash: 65.4 ± 44.7 ms p90: 147.5 p95: 155.6 p99: 172.0
+  getProgramAccounts for Pyth: 118.7 ± 159.6 ms p90: 172.4 p95: 295.1 p99: 1432.2
+  getAccount for Pyth BTC/USD price feed: 49.7 ± 23.2 ms p90: 62.5 p95: 91.1 p99: 162.5
+Testing at 200 queries per second
+  getSlot: 65.7 ± 68.1 ms p90: 147.9 p95: 168.5 p99: 567.3
+  getRecentBlockhash: 59.1 ± 59.1 ms p90: 129.0 p95: 146.9 p99: 542.3
+  getProgramAccounts for Pyth: 150.8 ± 91.6 ms p90: 295.5 p95: 420.4 p99: 472.9
+  getAccount for Pyth BTC/USD price feed: 47.8 ± 16.8 ms p90: 59.5 p95: 64.9 p99: 167.0
+```
+
+This output shows how average and tail latency of each API call grows as load increases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/client": "^2.4.0",
+        "@pythnetwork/client": "^2.5.3",
         "@solana/web3.js": "^1.30.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.1",
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@pythnetwork/client": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.4.0.tgz",
-      "integrity": "sha512-CRoqX7r1fjogpLNl8DwJ3ihAfi68gDbQw0nO0/FLd/MyW5s+cMWjrCJsKOrl/NoYqugHI9c8ogi8i2Hbh/IzMQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.5.3.tgz",
+      "integrity": "sha512-NBLxPnA6A3tZb/DYUooD4SO63UJ70s9DzzFPGXcQNBR9itcycp7aaV+UA5oUPloD/4UHL9soo2fRuDVur0gmhA==",
       "dependencies": {
         "@solana/web3.js": "^1.30.2",
         "assert": "^2.0.0",
@@ -8161,9 +8161,9 @@
       }
     },
     "@pythnetwork/client": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.4.0.tgz",
-      "integrity": "sha512-CRoqX7r1fjogpLNl8DwJ3ihAfi68gDbQw0nO0/FLd/MyW5s+cMWjrCJsKOrl/NoYqugHI9c8ogi8i2Hbh/IzMQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.5.3.tgz",
+      "integrity": "sha512-NBLxPnA6A3tZb/DYUooD4SO63UJ70s9DzzFPGXcQNBR9itcycp7aaV+UA5oUPloD/4UHL9soo2fRuDVur0gmhA==",
       "requires": {
         "@solana/web3.js": "^1.30.2",
         "assert": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@pythnetwork/client": "^2.4.0",
+    "@pythnetwork/client": "^2.5.3",
     "@solana/web3.js": "^1.30.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "monitor": "ts-node src/monitor.ts",
-    "validate": "ts-node src/validate_historical.ts"
+    "validate": "ts-node src/validate_historical.ts",
+    "benchmark": "ts-node src/rpc_benchmark.ts"
   },
   "keywords": [
     "pyth",

--- a/src/rpc_benchmark.ts
+++ b/src/rpc_benchmark.ts
@@ -1,0 +1,149 @@
+import {AccountInfo, Cluster, clusterApiUrl, Commitment, Connection, Context, PublicKey} from '@solana/web3.js';
+import {LowSlotHitRate, Price, PublisherPrice, Validator} from "./validation";
+import {getPythProgramKeyForCluster, PriceData, Product, PythConnection} from "@pythnetwork/client";
+
+require('dotenv').config()
+
+const SOLANA_CLUSTER_NAME: Cluster = process.env.SOLANA_CLUSTER_NAME ? process.env.SOLANA_CLUSTER_NAME as Cluster : 'mainnet-beta'
+const SOLANA_CLUSTER_URL = process.env.SOLANA_RPC_ENDPOINT ? process.env.SOLANA_RPC_ENDPOINT : clusterApiUrl(SOLANA_CLUSTER_NAME)
+const SOLANA_CONNECTION_COMMITMENT: Commitment = process.env.SOLANA_CONNECTION_COMMITMENT ? process.env.SOLANA_CONNECTION_COMMITMENT as Commitment : 'finalized'
+console.log(
+  `Connecting to ${SOLANA_CLUSTER_NAME} via ${SOLANA_CLUSTER_URL} with commitment ${SOLANA_CONNECTION_COMMITMENT}`
+)
+
+// const PUBLISHER_KEY: string | undefined = process.env.PUBLISHER_KEY
+
+const connection = new Connection(
+  SOLANA_CLUSTER_URL,
+  SOLANA_CONNECTION_COMMITMENT
+)
+// const pythConnection = new PythConnection(connection, PYTH_PROGRAM_KEY, SOLANA_CONNECTION_COMMITMENT)
+
+interface BenchmarkStats {
+  mean: number,
+  variance: number,
+  numSamples: number,
+  p90: number,
+  p95: number,
+  p99: number,
+}
+
+async function sleep(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
+
+export class RpcLoadGenerator {
+  load_fn: () => Promise<any>;
+  queries_per_second: number;
+  active: boolean;
+
+  constructor(load_fn: () => Promise<any>, queries_per_second: number) {
+    this.load_fn = load_fn;
+    this.queries_per_second = queries_per_second;
+    this.active = false;
+  }
+
+  public async start() {
+    if (this.queries_per_second == 0) {
+      return;
+    }
+
+    this.active = true;
+    while (this.active) {
+      this.load_fn();
+      await sleep(1000 / this.queries_per_second);
+    }
+  }
+
+  public async stop() {
+    this.active = false;
+  }
+}
+
+// Current time in microseconds
+function milliTime(): number {
+  let [secs, nanos] = process.hrtime();
+  return secs * 1000 + nanos / 1000000;
+}
+
+async function benchmark(method: (() => Promise<any>), n: number): Promise<BenchmarkStats> {
+  let results: number[] = []
+
+  let total: number = 0;
+  for (let i = 0; i < n; i++) {
+    let start = milliTime()
+    await method()
+    let end = milliTime()
+
+    let latency = end - start
+    results.push(latency)
+    total += latency
+
+    // sleep a bit to prevent rate limiting.
+    sleep(50);
+  }
+
+  let mean = total / n;
+  let variance = results.map(x => (x - mean) * (x - mean)).reduce((x, y) => x + y) / n;
+
+  results.sort((a, b) => a - b)
+
+  console.log(results)
+  console.log(Math.floor(0.90 * n))
+
+  return {
+    mean,
+    variance,
+    numSamples: n,
+    p90: results[Math.floor(0.90 * n)],
+    p95: results[Math.floor(0.95 * n)],
+    p99: results[Math.floor(0.99 * n)],
+  };
+}
+
+async function main() {
+
+  const PYTH_PROGRAM_KEY = getPythProgramKeyForCluster(SOLANA_CLUSTER_NAME);
+  const pythHttpClient = new PythHttpClient(connection, PYTH_PROGRAM_KEY, SOLANA_CONNECTION_COMMITMENT);
+
+
+  let methods = {
+    'getSlot': () => connection.getSlot(),
+    'getRecentBlockhash': () => connection.getRecentBlockhash(),
+    'getProgramAccounts(pyth)': () => connection.getProgramAccounts(PYTH_PROGRAM_KEY),
+
+    // TODO: get a price feed account repeatedly
+    'getAccount': () => connection.getAccountInfo(),
+  }
+
+  let load_conditions = [
+    0,
+    10,
+    30,
+    50,
+    100,
+  ]
+
+  let benchmark_queries = 50
+
+  // Warm up the RPC node (the first queries are usually slower)
+  console.log("Warming up RPC node...")
+  await benchmark(() => connection.getSlot(), 5);
+
+  for (let i = 0; i < load_conditions.length; i++) {
+    let qps = load_conditions[i];
+    console.log(`Testing at ${qps} queries per second`)
+
+    let load = new RpcLoadGenerator(() => connection.getSlot(), qps);
+    load.start()
+
+    for (let [name, bench_fn] of Object.entries(methods)) {
+      let results = await benchmark(bench_fn, benchmark_queries);
+      console.log(`  ${name}: ${results.mean.toFixed(1)} ± ${Math.sqrt(results.variance).toFixed(1)} ms p90: ${results.p90.toFixed(1)} p95: ${results.p95.toFixed(1)} p99: ${results.p99.toFixed(1)}`)
+    }
+
+    load.stop()
+  }
+}
+
+main()


### PR DESCRIPTION
Publishers need high-performance Solana RPC nodes. This change adds a script to benchmark RPC node latency. This script will be helpful to publishers trying to understand whether their RPC nodes are working well.